### PR TITLE
horizontal scaling in timeline fixed on chrome

### DIFF
--- a/src/gui.js
+++ b/src/gui.js
@@ -844,8 +844,8 @@ let AutomatonGUI = ( _automaton, _parent ) => {
 		if ( event.shiftKey ) {
 			let cursorT = gui.rmapTime( gui.canvasMouseX );
 
-			gui.timelineMinT -= ( cursorT - gui.timelineMinT ) * 0.005 * event.deltaY;
-			gui.timelineMaxT += ( gui.timelineMaxT - cursorT ) * 0.005 * event.deltaY;
+			gui.timelineMinT -= ( cursorT - gui.timelineMinT ) * 0.005 * event.deltaX;
+			gui.timelineMaxT += ( gui.timelineMaxT - cursorT ) * 0.005 * event.deltaX;
 
 			let el = gui.timelineMinT < 0.0;
 			let er = gui.automaton.length < gui.timelineMaxT;


### PR DESCRIPTION
Holding shift puts the mouse wheel value in deltaX, rather than deltaY, this change fixes the horizontal zooming of the timeline.