### PR TITLE
tidy up types

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -49,7 +49,7 @@ module.exports = {
 
         // variables
         "@typescript-eslint/no-unused-vars": [ "warn" ], // draw yellow line under unused vars
-        "no-undef": [ "warn" ], // draws yellow line under undefined vars
+        // "no-undef": [ "warn" ], // draws yellow line under undefined vars // it doesn't work on typescript sometimes
         "no-var": [ "error" ], // fuck you, var
         "prefer-const": [ "error" ], // const is better than let
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /dist
 /docs
 /types
+/ts*
 /node_modules
 **/*.log

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "repository": "https://github.com/FMS-Cat/automaton",
   "author": "FMS-Cat",
   "types": "types/index.d.ts",
+  "typesVersions": {
+    "<3.8": { "*": [ "ts3.4/*" ] }
+  },
   "license": "MIT",
   "scripts": {
     "dev": "webpack-dev-server --hot --mode development",
@@ -15,7 +18,7 @@
     "build": "yarn build-dev && yarn build-prod && yarn types",
     "build-dev": "webpack --mode development",
     "build-prod": "webpack --mode production",
-    "types": "tsc --emitDeclarationOnly",
+    "types": "tsc --emitDeclarationOnly && downlevel-dts . ts3.4",
     "docs": "typedoc --out docs --mode file --excludeNotExported",
     "lint": "eslint \"src/**/*.ts\"",
     "test": "jest"
@@ -31,6 +34,7 @@
     "@types/jest": "^25.1.4",
     "@typescript-eslint/eslint-plugin": "^2.23.0",
     "@typescript-eslint/parser": "^2.23.0",
+    "downlevel-dts": "^0.4.0",
     "eslint": "^6.8.0",
     "eslint-plugin-jest": "^23.8.2",
     "fork-ts-checker-webpack-plugin": "^4.1.0",
@@ -40,7 +44,7 @@
     "rimraf": "^3.0.2",
     "ts-jest": "^25.2.1",
     "ts-loader": "^6.2.1",
-    "typedoc": "^0.16.11",
+    "typedoc": "^0.17.6",
     "typescript": "^3.8.3",
     "webpack": "^4.42.0",
     "webpack-cli": "^3.3.11",

--- a/src/Automaton.ts
+++ b/src/Automaton.ts
@@ -1,7 +1,8 @@
-import { Channel, ChannelUpdateEvent } from './Channel';
+import { Channel } from './Channel';
+import type { ChannelUpdateEvent } from './types/ChannelUpdateEvent';
 import { Curve } from './Curve';
-import { FxDefinition } from './types/FxDefinition';
-import { SerializedAutomaton } from './types/SerializedAutomaton';
+import type { FxDefinition } from './types/FxDefinition';
+import type { SerializedAutomaton } from './types/SerializedAutomaton';
 
 /**
  * IT'S AUTOMATON!

--- a/src/Channel.ts
+++ b/src/Channel.ts
@@ -1,36 +1,7 @@
 import { Automaton } from './Automaton';
 import { ChannelItem } from './ChannelItem';
-import { SerializedChannel } from './types/SerializedChannel';
-
-/**
- * Represent an event that is emitted by [[Channel.update]].
- */
-export interface ChannelUpdateEvent {
-  /**
-   * Current time in the current item.
-   */
-  time: number;
-
-  /**
-   * Current value of the channel.
-   */
-  value: number;
-
-  /**
-   * `true` if the update was the first call of the item.
-   */
-  init?: true;
-
-  /**
-   * `true` if the update was the last call of the item.
-   */
-  uninit?: true;
-
-  /**
-   * The progress of the item.
-   */
-  progress: number;
-}
+import type { ChannelUpdateEvent } from './types/ChannelUpdateEvent';
+import type { SerializedChannel } from './types/SerializedChannel';
 
 /**
  * It represents a channel of Automaton.

--- a/src/ChannelItem.ts
+++ b/src/ChannelItem.ts
@@ -1,5 +1,5 @@
 import { Automaton, Curve } from '.';
-import { SerializedChannelItem } from './types/SerializedChannelItem';
+import type { SerializedChannelItem } from './types/SerializedChannelItem';
 
 /**
  * Represents an item of a [[Channel]].

--- a/src/Curve.ts
+++ b/src/Curve.ts
@@ -1,8 +1,8 @@
 import { Automaton } from './Automaton';
-import { BezierNode } from './types/BezierNode';
-import { FxContext } from './types/FxDefinition';
-import { FxSection } from './types/FxSection';
-import { SerializedCurve } from './types/SerializedCurve';
+import type { BezierNode } from './types/BezierNode';
+import type { FxContext } from './types/FxDefinition';
+import type { FxSection } from './types/FxSection';
+import type { SerializedCurve } from './types/SerializedCurve';
 import { bezierEasing } from './utils/bezierEasing';
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,15 @@
-export * from './types';
+export type { BezierControlPoint, BezierNode, SerializedBezierNode } from './types/BezierNode';
+export type { FxContext, FxDefinition, FxParam } from './types/FxDefinition';
+export type { FxSection, SerializedFxSection } from './types/FxSection';
+export type { SerializedAutomaton } from './types/SerializedAutomaton';
+export type { SerializedChannel } from './types/SerializedChannel';
+export type { SerializedChannelItem } from './types/SerializedChannelItem';
+export type { SerializedCurve } from './types/SerializedCurve';
 
 export { Automaton } from './Automaton';
-export { Channel, ChannelUpdateEvent } from './Channel';
+export { Channel } from './Channel';
 export { ChannelItem } from './ChannelItem';
 export { Curve } from './Curve';
+
+import { Automaton } from './Automaton';
+export default Automaton;

--- a/src/tests/Automaton.test.ts
+++ b/src/tests/Automaton.test.ts
@@ -1,8 +1,8 @@
 /* eslint-env jest */
 
 import { Automaton } from '../Automaton';
-import { ChannelUpdateEvent } from '../Channel';
-import { SerializedAutomaton } from '../types';
+import type { ChannelUpdateEvent } from '../types/ChannelUpdateEvent';
+import type { SerializedAutomaton } from '../types/SerializedAutomaton';
 
 const data: SerializedAutomaton = {
   resolution: 100.0,

--- a/src/tests/Channel.test.ts
+++ b/src/tests/Channel.test.ts
@@ -1,8 +1,9 @@
 /* eslint-env jest */
 
-import { SerializedAutomaton, SerializedChannel } from '../types';
 import { Automaton } from '../Automaton';
 import { Channel } from '../Channel';
+import type { SerializedAutomaton } from '../types/SerializedAutomaton';
+import type { SerializedChannel } from '../types/SerializedChannel';
 
 const data: SerializedAutomaton = {
   resolution: 100.0,

--- a/src/types/ChannelUpdateEvent.ts
+++ b/src/types/ChannelUpdateEvent.ts
@@ -1,0 +1,29 @@
+/**
+ * Represent an event that is emitted by [[Channel.update]].
+ */
+export interface ChannelUpdateEvent {
+  /**
+   * Current time in the current item.
+   */
+  time: number;
+
+  /**
+   * Current value of the channel.
+   */
+  value: number;
+
+  /**
+   * `true` if the update was the first call of the item.
+   */
+  init?: true;
+
+  /**
+   * `true` if the update was the last call of the item.
+   */
+  uninit?: true;
+
+  /**
+   * The progress of the item.
+   */
+  progress: number;
+}

--- a/src/types/SerializedAutomaton.ts
+++ b/src/types/SerializedAutomaton.ts
@@ -1,5 +1,5 @@
-import { SerializedChannel } from './SerializedChannel';
-import { SerializedCurve } from './SerializedCurve';
+import type { SerializedChannel } from './SerializedChannel';
+import type { SerializedCurve } from './SerializedCurve';
 
 /**
  * Interface of serialized automaton data.

--- a/src/types/SerializedChannel.ts
+++ b/src/types/SerializedChannel.ts
@@ -1,4 +1,4 @@
-import { SerializedChannelItem } from './SerializedChannelItem';
+import type { SerializedChannelItem } from './SerializedChannelItem';
 
 /**
  * Interface of a serialized channel.

--- a/src/types/SerializedCurve.ts
+++ b/src/types/SerializedCurve.ts
@@ -1,5 +1,5 @@
-import { SerializedBezierNode } from './BezierNode';
-import { SerializedFxSection } from './FxSection';
+import type { SerializedBezierNode } from './BezierNode';
+import type { SerializedFxSection } from './FxSection';
 
 /**
  * Interface of a serialized curve.

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,7 +1,0 @@
-export * from './BezierNode';
-export * from './FxDefinition';
-export * from './FxSection';
-export * from './SerializedAutomaton';
-export * from './SerializedChannel';
-export * from './SerializedChannelItem';
-export * from './SerializedCurve';

--- a/src/utils/bezierEasing.ts
+++ b/src/utils/bezierEasing.ts
@@ -1,4 +1,4 @@
-import { BezierNode } from '../types/BezierNode';
+import type { BezierNode } from '../types/BezierNode';
 
 interface CubicBezierControlPoints {
   p0: number;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,5 @@
     "declarationDir": "./types"
   },
   "include": [ "src" ],
-  "exclude": [ "node_modules" ]
+  "exclude": [ "node_modules", "**/tests/**/*" ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -436,7 +436,7 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
   integrity sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==
 
-"@types/minimatch@*", "@types/minimatch@3.0.3":
+"@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
 
@@ -1005,13 +1005,6 @@ babel-preset-jest@^25.1.0:
     "@babel/plugin-syntax-bigint" "^7.0.0"
     "@babel/plugin-syntax-object-rest-spread" "^7.0.0"
     babel-plugin-jest-hoist "^25.1.0"
-
-backbone@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/backbone/-/backbone-1.4.0.tgz#54db4de9df7c3811c3f032f34749a4cd27f3bd12"
-  integrity sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==
-  dependencies:
-    underscore ">=1.8.3"
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -1905,6 +1898,14 @@ domexception@^1.0.1:
   integrity sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==
   dependencies:
     webidl-conversions "^4.0.2"
+
+downlevel-dts@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/downlevel-dts/-/downlevel-dts-0.4.0.tgz#43f9f649c8b137373d76b4ee396d5a0227c10ddb"
+  integrity sha512-nh5vM3n2pRhPwZqh0iWo5gpItPAYEGEWw9yd0YpI+lO60B7A3A6iJlxDbt7kKVNbqBXKsptL+jwE/Yg5Go66WQ==
+  dependencies:
+    shelljs "^0.8.3"
+    typescript "^3.8.0-dev.20200111"
 
 duplexify@^3.4.2, duplexify@^3.6.0:
   version "3.7.1"
@@ -2803,14 +2804,15 @@ handle-thing@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.0.tgz#0e039695ff50c93fc288557d696f3c1dc6776754"
 
-handlebars@^4.7.2:
-  version "4.7.3"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.3.tgz#8ece2797826886cf8082d1726ff21d2a022550ee"
-  integrity sha512-SRGwSYuNfx8DwHD/6InAPzD6RgeruWLT+B8e8a7gGs8FWgHzlExpTFMEq2IA6QpAfOClpKHy6+8IqTjeBCu6Kg==
+handlebars@^4.7.6:
+  version "4.7.6"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.6.tgz#d4c05c1baf90e9945f77aa68a7a219aa4a7df74e"
+  integrity sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==
   dependencies:
+    minimist "^1.2.5"
     neo-async "^2.6.0"
-    optimist "^0.6.1"
     source-map "^0.6.1"
+    wordwrap "^1.0.0"
   optionalDependencies:
     uglify-js "^3.1.4"
 
@@ -2901,10 +2903,10 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
-highlight.js@^9.17.1:
-  version "9.18.1"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.18.1.tgz#ed21aa001fe6252bb10a3d76d47573c6539fe13c"
-  integrity sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg==
+highlight.js@^10.0.0:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.0.1.tgz#32ba25ee532291b86d1480b809a7e38bcd7f6dfe"
+  integrity sha512-l1HB5S9nmBuvurFIOPbpeJv4psKh2MyKCTOYRK/E6dwRXkbG96PLH7amP/xpGNyZOK8OWqv45DxLS/ZAIb3n9w==
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
@@ -3791,11 +3793,6 @@ jest@^25.1.0:
     import-local "^3.0.2"
     jest-cli "^25.1.0"
 
-jquery@^3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
-  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
-
 js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
@@ -4072,10 +4069,10 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-marked@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-0.8.0.tgz#ec5c0c9b93878dc52dd54be8d0e524097bd81a99"
-  integrity sha512-MyUe+T/Pw4TZufHkzAfDj6HarCBWia2y27/bhuYkTaiUnfDYFnCP3KUN+9oM7Wi6JA2rymtVYbQu3spE0GCmxQ==
+marked@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-1.0.0.tgz#d35784245a04871e5988a491e28867362e941693"
+  integrity sha512-Wo+L1pWTVibfrSr+TTtMuiMfNzmZWiOPeO7rZsQUY5bgsxpHesBEcIWJloWVTFnrMXnf/TL30eTFSGJddmQAng==
 
 md5.js@^1.3.4:
   version "1.3.5"
@@ -4234,7 +4231,7 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@^1.1.1:
+minimist@^1.1.1, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -4242,10 +4239,6 @@ minimist@^1.1.1:
 minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-
-minimist@~0.0.1:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
 minipass@^2.2.1, minipass@^2.3.3:
   version "2.3.3"
@@ -4604,13 +4597,6 @@ opn@^5.5.0:
   integrity sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==
   dependencies:
     is-wsl "^1.1.0"
-
-optimist@^0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
-  dependencies:
-    minimist "~0.0.1"
-    wordwrap "~0.0.2"
 
 optionator@^0.8.1, optionator@^0.8.3:
   version "0.8.3"
@@ -5555,10 +5541,10 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shelljs@^0.8.3:
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.3.tgz#a7f3319520ebf09ee81275b2368adb286659b097"
-  integrity sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==
+shelljs@^0.8.3, shelljs@^0.8.4:
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.4.tgz#de7684feeb767f8716b326078a8a00875890e3c2"
+  integrity sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==
   dependencies:
     glob "^7.0.0"
     interpret "^1.0.0"
@@ -6256,39 +6242,30 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typedoc-default-themes@^0.7.2:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.7.2.tgz#1e9896f920b58e6da0bba9d7e643738d02405a5a"
-  integrity sha512-fiFKlFO6VTqjcno8w6WpTsbCgXmfPHVjnLfYkmByZE7moaz+E2DSpAT+oHtDHv7E0BM5kAhPrHJELP2J2Y2T9A==
+typedoc-default-themes@^0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.10.1.tgz#eb27b7d689457c7ec843e47ec0d3e500581296a7"
+  integrity sha512-SuqAQI0CkwhqSJ2kaVTgl37cWs733uy9UGUqwtcds8pkFK8oRF4rZmCq+FXTGIb9hIUOu40rf5Kojg0Ha6akeg==
   dependencies:
-    backbone "^1.4.0"
-    jquery "^3.4.1"
     lunr "^2.3.8"
-    underscore "^1.9.1"
 
-typedoc@^0.16.11:
-  version "0.16.11"
-  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.16.11.tgz#95f862c6eba78533edc9af7096d2295b718eddc1"
-  integrity sha512-YEa5i0/n0yYmLJISJ5+po6seYfJQJ5lQYcHCPF9ffTF92DB/TAZO/QrazX5skPHNPtmlIht5FdTXCM2kC7jQFQ==
+typedoc@^0.17.6:
+  version "0.17.6"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.17.6.tgz#cab87a72c10e05429016d659a4c3071a5a3ffb61"
+  integrity sha512-pQiYnhG3yJk7939cv2n8uFoTsSgy5Hfiw0dgOQYa9nT9Ya1013dMctQdAXMj8JbNu7KhcauQyq9Zql9D/TziLw==
   dependencies:
-    "@types/minimatch" "3.0.3"
     fs-extra "^8.1.0"
-    handlebars "^4.7.2"
-    highlight.js "^9.17.1"
+    handlebars "^4.7.6"
+    highlight.js "^10.0.0"
     lodash "^4.17.15"
-    marked "^0.8.0"
+    lunr "^2.3.8"
+    marked "1.0.0"
     minimatch "^3.0.0"
     progress "^2.0.3"
-    shelljs "^0.8.3"
-    typedoc-default-themes "^0.7.2"
-    typescript "3.7.x"
+    shelljs "^0.8.4"
+    typedoc-default-themes "^0.10.1"
 
-typescript@3.7.x:
-  version "3.7.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
-  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
-
-typescript@^3.8.3:
+typescript@^3.8.0-dev.20200111, typescript@^3.8.3:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
   integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
@@ -6299,11 +6276,6 @@ uglify-js@^3.1.4:
   dependencies:
     commander "~2.17.1"
     source-map "~0.6.1"
-
-underscore@>=1.8.3, underscore@^1.9.1:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.9.1.tgz#06dce34a0e68a7babc29b365b8e74b8925203961"
-  integrity sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==
 
 union-value@^1.0.0:
   version "1.0.0"
@@ -6665,9 +6637,10 @@ word-wrap@~1.2.3:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
 
-wordwrap@~0.0.2:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
+wordwrap@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
+  integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
 worker-farm@^1.7.0:
   version "1.7.0"


### PR DESCRIPTION
- 💻 Utilize TS3.8 type-only imports
    - 💪 Thanks to this, build size is now 9.5KB
- 📦 install `downlevel-dts`
    - 💪 types are now TS3.4 compatible
- 📦 update `typedoc`