### PR TITLE
change var output namespace to AUTOMATON

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,6 +27,7 @@ Repository: ${ packageJson.repository }`
     output: {
       path: path.join( __dirname, 'dist' ),
       filename: DEV ? 'automaton.js' : 'automaton.min.js',
+      library: 'AUTOMATON',
       libraryTarget: 'umd',
       globalObject: 'this',
     },


### PR DESCRIPTION
- 💡 add a namespace `AUTOMATON` for var output (using `<script>`)
    - 🚨 You'll need `AUTOMATON.` before classes if you're using Automaton via `<script>`

```js
const { Automaton } = AUTOMATON;
```
