### PR TITLE
ChannelItem: add reset feature

### DIFF
--- a/src/ChannelItem.ts
+++ b/src/ChannelItem.ts
@@ -26,6 +26,11 @@ export class ChannelItem {
   public value!: number;
 
   /**
+   * Whether reset channels value to zero at the end of this item or not.
+   */
+  public reset?: boolean;
+
+  /**
    * This will only make sense when {@link curve} is specified.
    * The time offset of the item.
    */
@@ -67,6 +72,10 @@ export class ChannelItem {
   }
 
   public getValue( time: number ): number {
+    if ( this.reset && this.length <= time ) {
+      return 0.0;
+    }
+
     if ( this.curve ) {
       const t = this.offset! + time * this.speed!;
       return this.value + this.amp * this.curve.getValue( t );
@@ -86,6 +95,7 @@ export class ChannelItem {
     this.offset = data.offset ?? 0.0;
     this.speed = data.speed ?? 1.0;
     this.amp = data.amp ?? 1.0;
+    this.reset = data.reset;
     if ( data.curve != null ) {
       this.curve = this.__automaton.getCurve( data.curve )!;
       this.length = data.length ?? this.curve.length ?? 0.0;

--- a/src/tests/Channel.test.ts
+++ b/src/tests/Channel.test.ts
@@ -3,7 +3,6 @@
 import { Automaton } from '../Automaton';
 import { Channel } from '../Channel';
 import type { SerializedAutomaton } from '../types/SerializedAutomaton';
-import type { SerializedChannel } from '../types/SerializedChannel';
 
 const data: SerializedAutomaton = {
   resolution: 100.0,
@@ -14,14 +13,6 @@ const data: SerializedAutomaton = {
   channels: {}
 };
 
-const serializedChannelWithALinearCurve: SerializedChannel = {
-  items: [ { curve: 0, time: 0.1 } ]
-};
-
-const serializedChannelWithAConstantCurve: SerializedChannel = {
-  items: [ { curve: 1, time: 0.1 } ]
-};
-
 describe( 'Channel', () => {
   let automaton = new Automaton( data );
 
@@ -29,53 +20,48 @@ describe( 'Channel', () => {
     automaton = new Automaton( data );
   } );
 
-  it( 'must be instantiated correctly (serializedChannelWithALinearCurve)', () => {
-    const channel = new Channel( automaton, serializedChannelWithALinearCurve );
-    expect( channel ).toBeInstanceOf( Channel );
-  } );
-
-  it( 'must be instantiated correctly (serializedChannelWithAConstantCurve)', () => {
-    const channel = new Channel( automaton, serializedChannelWithAConstantCurve );
+  it( 'must be instantiated correctly', () => {
+    const channel = new Channel( automaton, {
+      items: [ { curve: 0, time: 0.1 } ]
+    } );
     expect( channel ).toBeInstanceOf( Channel );
   } );
 
   describe( 'getValue', () => {
-    let channelWithALinearCurve = new Channel( automaton, serializedChannelWithALinearCurve );
-    let channelWithAConstantCurve = new Channel( automaton, serializedChannelWithAConstantCurve );
-
-    beforeEach( () => {
-      channelWithALinearCurve = new Channel( automaton, serializedChannelWithALinearCurve );
-      channelWithAConstantCurve = new Channel( automaton, serializedChannelWithAConstantCurve );
+    it( 'must handle an item of a linear curve properly', () => {
+      const channel = new Channel( automaton, {
+        items: [ { curve: 0, time: 0.1 } ]
+      } );
+      expect( channel.getValue( 0.05 ) ).toBeCloseTo( 0.0 );
+      expect( channel.getValue( 0.4 ) ).toBeCloseTo( 0.5 );
+      expect( channel.getValue( 0.9 ) ).toBeCloseTo( 1.0 );
     } );
 
-    it( 'must return a proper value (channelWithALinearCurve, before the curve starts)', () => {
-      const result = channelWithALinearCurve.getValue( 0.05 );
-      expect( result ).toBeCloseTo( 0.0 );
+    it( 'must handle an item of a constant curve properly', () => {
+      const channel = new Channel( automaton, {
+        items: [ { curve: 1, time: 0.1 } ]
+      } );
+      expect( channel.getValue( 0.05 ) ).toBeCloseTo( 0.0 );
+      expect( channel.getValue( 0.4 ) ).toBeCloseTo( 2.0 );
+      expect( channel.getValue( 0.9 ) ).toBeCloseTo( 2.0 );
     } );
 
-    it( 'must return a proper value (channelWithAConstantCurve, before the curve starts)', () => {
-      const result = channelWithAConstantCurve.getValue( 0.05 );
-      expect( result ).toBeCloseTo( 0.0 );
+    it( 'must handle a constant item with reset properly', () => {
+      const channel = new Channel( automaton, {
+        items: [ { time: 0.5, length: 0.5, value: 1.0, reset: true } ]
+      } );
+      expect( channel.getValue( 0.3 ) ).toBeCloseTo( 0.0 );
+      expect( channel.getValue( 0.6 ) ).toBeCloseTo( 1.0 );
+      expect( channel.getValue( 1.2 ) ).toBeCloseTo( 0.0 );
     } );
 
-    it( 'must return a proper value (channelWithALinearCurve, during the curve)', () => {
-      const result = channelWithALinearCurve.getValue( 0.4 );
-      expect( result ).toBeCloseTo( 0.5 );
-    } );
-
-    it( 'must return a proper value (channelWithAConstantCurve, during the curve)', () => {
-      const result = channelWithAConstantCurve.getValue( 0.4 );
-      expect( result ).toBeCloseTo( 2.0 );
-    } );
-
-    it( 'must return a proper value (channelWithALinearCurve, after the curve ends)', () => {
-      const result = channelWithALinearCurve.getValue( 0.9 );
-      expect( result ).toBeCloseTo( 1.0 );
-    } );
-
-    it( 'must return a proper value (channelWithAConstantCurve, after the curve ends)', () => {
-      const result = channelWithAConstantCurve.getValue( 0.9 );
-      expect( result ).toBeCloseTo( 2.0 );
+    it( 'must handle an item of a linear curve with reset properly', () => {
+      const channel = new Channel( automaton, {
+        items: [ { curve: 0, time: 0.1, reset: true } ]
+      } );
+      expect( channel.getValue( 0.05 ) ).toBeCloseTo( 0.0 );
+      expect( channel.getValue( 0.4 ) ).toBeCloseTo( 0.5 );
+      expect( channel.getValue( 0.9 ) ).toBeCloseTo( 0.0 );
     } );
   } );
 } );

--- a/src/types/SerializedChannelItem.ts
+++ b/src/types/SerializedChannelItem.ts
@@ -15,6 +15,12 @@ export interface SerializedChannelItem {
   value?: number;
 
   /**
+   * Whether reset channels value to zero at the end of this item or not.
+   * `false` by default.
+   */
+  reset?: boolean;
+
+  /**
    * If it is not defined, interpret the item represents a constant item.
    */
   curve?: number | null;


### PR DESCRIPTION
Add `reset: true` to an item makes the value of its channel reset to zero automatically