### PR TITLE
New GUI option: useBeatInGUI

### DIFF
--- a/packages/automaton-with-gui/src/types/GUISettings.ts
+++ b/packages/automaton-with-gui/src/types/GUISettings.ts
@@ -33,6 +33,11 @@ export interface GUISettings {
   snapBeatBPM: number;
 
   /**
+   * Use beat instead of time in GUI.
+   */
+  useBeatInGUI: boolean;
+
+  /**
    * Fractional precision for minimized data, for time axis.
    */
   minimizedPrecisionTime: number;
@@ -50,6 +55,7 @@ export const defaultGUISettings: Readonly<GUISettings> = {
   snapValueInterval: 0.1,
   snapBeatActive: false,
   snapBeatBPM: 140.0,
+  useBeatInGUI: false,
   minimizedPrecisionTime: 3,
   minimizedPrecisionValue: 3,
 };

--- a/packages/automaton-with-gui/src/view/components/Header.tsx
+++ b/packages/automaton-with-gui/src/view/components/Header.tsx
@@ -300,6 +300,17 @@ const Header = ( { className }: HeaderProps ): JSX.Element => {
           data-stalker="Snapping"
         />
         <Button
+          as={ Icons.Beat }
+          onClick={ () => {
+            dispatch( {
+              type: 'Settings/ChangeMode',
+              mode: settingsMode === 'beat' ? 'none' : 'beat'
+            } );
+          } }
+          active={ ( settingsMode === 'beat' ? 1 : 0 ) as any as boolean } // fuck
+          data-stalker="Beat"
+        />
+        <Button
           as={ Icons.Cog }
           onClick={ () => {
             dispatch( {

--- a/packages/automaton-with-gui/src/view/components/Header.tsx
+++ b/packages/automaton-with-gui/src/view/components/Header.tsx
@@ -1,8 +1,8 @@
-import { AutomatonWithGUI } from '../../AutomatonWithGUI';
 import { Colors } from '../constants/Colors';
 import { HeaderSeekbar } from './HeaderSeekbar';
 import { Icons } from '../icons/Icons';
 import { Metrics } from '../constants/Metrics';
+import { minimizeData } from '../../minimizeData';
 import { performRedo, performUndo } from '../history/HistoryCommand';
 import { showToasty } from '../states/Toasty';
 import { useDispatch, useSelector } from '../states/store';
@@ -229,7 +229,7 @@ const Header = ( { className }: HeaderProps ): JSX.Element => {
                   precisionTime: automaton.guiSettings.minimizedPrecisionTime,
                   precisionValue: automaton.guiSettings.minimizedPrecisionValue
                 };
-                const minimized = AutomatonWithGUI.minimizeData( data, options );
+                const minimized = minimizeData( data, options );
                 save( JSON.stringify( minimized ) );
               }
             }

--- a/packages/automaton-with-gui/src/view/components/HeaderSeekbar.tsx
+++ b/packages/automaton-with-gui/src/view/components/HeaderSeekbar.tsx
@@ -3,15 +3,18 @@ import { MouseComboBit, mouseCombo } from '../utils/mouseCombo';
 import { clamp } from '../../utils/clamp';
 import { registerMouseEvent } from '../utils/registerMouseEvent';
 import { useDispatch, useSelector } from '../states/store';
+import { useTimeUnit } from '../utils/useTimeUnit';
 import React, { useCallback } from 'react';
 import styled from 'styled-components';
 
 // == microcomponent ===============================================================================
 const CurrentTime = ( { className }: { className?: string } ): JSX.Element => {
   const time = useSelector( ( state ) => state.automaton.time );
+  const { timeToDisplay } = useTimeUnit();
+
   return (
     <span className={ className }>
-      { time.toFixed( 3 ) }
+      { timeToDisplay( time, true ).toFixed( 3 ) }
     </span>
   );
 };
@@ -87,6 +90,7 @@ const HeaderSeekbar = ( { className }: HeaderSeekbarProps ): JSX.Element => {
     isSeeking: state.header.isSeeking,
     isSeekbarHovered: state.header.isSeekbarHovered
   } ) );
+  const { timeToDisplay } = useTimeUnit();
 
   const handleMouseDown = useCallback(
     ( event ) => mouseCombo( event, {
@@ -137,7 +141,7 @@ const HeaderSeekbar = ( { className }: HeaderSeekbarProps ): JSX.Element => {
       onMouseLeave={ handleMouseLeave }
     >
       <StyledCurrentTime />
-      <TotalTime> / { length.toFixed( 3 ) }</TotalTime>
+      <TotalTime> / { timeToDisplay( length, true ).toFixed( 3 ) }</TotalTime>
       <BarBG />
       <StyledBarFG
         isSeeking={ isSeeking }

--- a/packages/automaton-with-gui/src/view/components/Inspector.tsx
+++ b/packages/automaton-with-gui/src/view/components/Inspector.tsx
@@ -1,5 +1,6 @@
 import { Colors } from '../constants/Colors';
 import { Icons } from '../icons/Icons';
+import { InspectorBeat } from './InspectorBeat';
 import { InspectorChannelItem } from './InspectorChannelItem';
 import { InspectorCurveFx } from './InspectorCurveFx';
 import { InspectorCurveNode } from './InspectorCurveNode';
@@ -62,6 +63,8 @@ const Inspector = ( { className }: {
   let content: JSX.Element | null = null;
   if ( settingsMode === 'snapping' ) {
     content = <InspectorSnapping />;
+  } else if ( settingsMode === 'beat' ) {
+    content = <InspectorBeat />;
   } else if ( settingsMode === 'general' ) {
     content = <InspectorGeneral />;
   } else if ( mode === 'curve' ) {

--- a/packages/automaton-with-gui/src/view/components/InspectorBeat.tsx
+++ b/packages/automaton-with-gui/src/view/components/InspectorBeat.tsx
@@ -1,0 +1,61 @@
+import { BoolParam } from './BoolParam';
+import { InspectorHeader } from './InspectorHeader';
+import { InspectorHr } from './InspectorHr';
+import { InspectorItem } from './InspectorItem';
+import { NumberParam } from './NumberParam';
+import { useSelector } from '../states/store';
+import React from 'react';
+
+// == component ====================================================================================
+const InspectorBeat = (): JSX.Element | null => {
+  const { automaton, guiSettings } = useSelector( ( state ) => ( {
+    automaton: state.automaton.instance,
+    guiSettings: state.automaton.guiSettings
+  } ) );
+
+  return ( automaton && <>
+    <InspectorHeader text="Beat" />
+
+    <InspectorHr />
+
+    <InspectorItem
+      name="BPM"
+      description="Beat per minute of the song."
+    >
+      <NumberParam
+        type="float"
+        value={ guiSettings.snapBeatBPM }
+        onChange={ ( value ) => {
+          automaton.setGUISettings( 'snapBeatBPM', Math.max( 0.0, value ) );
+        } }
+      />
+    </InspectorItem>
+
+    <InspectorHr />
+
+    <InspectorItem
+      name="Beat Snap"
+      description="Make items snap to the beat."
+    >
+      <BoolParam
+        value={ guiSettings.snapBeatActive }
+        onChange={ ( value ) => {
+          automaton.setGUISettings( 'snapBeatActive', value );
+        } }
+      />
+    </InspectorItem>
+    <InspectorItem
+      name="Use Beat in GUI"
+      description="Show beat instead of time in GUI."
+    >
+      <BoolParam
+        value={ guiSettings.useBeatInGUI }
+        onChange={ ( value ) => {
+          automaton.setGUISettings( 'useBeatInGUI', value );
+        } }
+      />
+    </InspectorItem>
+  </> ) ?? null;
+};
+
+export { InspectorBeat };

--- a/packages/automaton-with-gui/src/view/components/InspectorChannelItem.tsx
+++ b/packages/automaton-with-gui/src/view/components/InspectorChannelItem.tsx
@@ -5,6 +5,7 @@ import { InspectorHr } from './InspectorHr';
 import { InspectorItem } from './InspectorItem';
 import { NumberParam } from './NumberParam';
 import { useDispatch, useSelector } from '../states/store';
+import { useTimeUnit } from '../utils/useTimeUnit';
 import React from 'react';
 import styled from 'styled-components';
 import type { StateChannelItem } from '../../types/StateChannelItem';
@@ -133,6 +134,7 @@ const InspectorChannelItem = ( props: Props ): JSX.Element | null => {
     stateItem: state.automaton.channels[ channelName ].items[ itemId ]
   } ) );
   const channel = automaton?.getChannel( channelName ) ?? null;
+  const { displayToTime, timeToDisplay } = useTimeUnit();
 
   return ( automaton && channel && (
     <Root className={ className }>
@@ -143,9 +145,9 @@ const InspectorChannelItem = ( props: Props ): JSX.Element | null => {
       <InspectorItem name="Time">
         <NumberParam
           type="float"
-          value={ stateItem.time }
-          onChange={ ( value ) => { channel.moveItem( itemId, value ); } }
-          onSettle={ ( time, timePrev ) => {
+          value={ timeToDisplay( stateItem.time, true ) }
+          onChange={ ( value ) => { channel.moveItem( itemId, displayToTime( value, true ) ); } }
+          onSettle={ ( value, valuePrev ) => {
             dispatch( {
               type: 'History/Push',
               description: 'Change Item Time',
@@ -154,8 +156,8 @@ const InspectorChannelItem = ( props: Props ): JSX.Element | null => {
                   type: 'channel/moveItem',
                   channel: channelName,
                   item: itemId,
-                  time,
-                  timePrev
+                  time: displayToTime( value, true ),
+                  timePrev: displayToTime( valuePrev, true ),
                 }
               ]
             } );
@@ -166,9 +168,9 @@ const InspectorChannelItem = ( props: Props ): JSX.Element | null => {
       <InspectorItem name="Length">
         <NumberParam
           type="float"
-          value={ stateItem.length }
-          onChange={ ( value ) => { channel.resizeItem( itemId, value ); } }
-          onSettle={ ( length, lengthPrev ) => {
+          value={ timeToDisplay( stateItem.length ) }
+          onChange={ ( value ) => { channel.resizeItem( itemId, displayToTime( value ) ); } }
+          onSettle={ ( value, valuePrev ) => {
             dispatch( {
               type: 'History/Push',
               description: 'Change Item Length',
@@ -177,8 +179,8 @@ const InspectorChannelItem = ( props: Props ): JSX.Element | null => {
                   type: 'channel/resizeItem',
                   channel: channelName,
                   item: itemId,
-                  length,
-                  lengthPrev,
+                  length: displayToTime( value ),
+                  lengthPrev: displayToTime( valuePrev ),
                   stretch: false
                 }
               ]

--- a/packages/automaton-with-gui/src/view/components/InspectorCurveFx.tsx
+++ b/packages/automaton-with-gui/src/view/components/InspectorCurveFx.tsx
@@ -6,6 +6,7 @@ import { InspectorItem } from './InspectorItem';
 import { NumberParam } from './NumberParam';
 import { clamp } from '../../utils/clamp';
 import { useDispatch, useSelector } from '../states/store';
+import { useTimeUnit } from '../utils/useTimeUnit';
 import React from 'react';
 
 // == component ====================================================================================
@@ -23,6 +24,7 @@ const InspectorCurveFx = ( props: InspectorCurveFxProps ): JSX.Element | null =>
   const curve = automaton?.getCurveById( props.curveId ) || null;
   const fx = curves[ props.curveId ].fxs[ props.fx ];
   const fxDefParams = automaton?.getFxDefinitionParams( fx.def );
+  const { displayToTime, timeToDisplay } = useTimeUnit();
 
   return ( automaton && curve && <>
     <InspectorHeader text={ `Fx: ${ automaton.getFxDefinitionName( fx.def ) }` } />
@@ -32,9 +34,9 @@ const InspectorCurveFx = ( props: InspectorCurveFxProps ): JSX.Element | null =>
     <InspectorItem name="Time">
       <NumberParam
         type="float"
-        value={ fx.time }
-        onChange={ ( value ) => { curve.moveFx( fx.$id, value ); } }
-        onSettle={ ( time, timePrev ) => {
+        value={ timeToDisplay( fx.time ) }
+        onChange={ ( value ) => { curve.moveFx( fx.$id, displayToTime( value ) ); } }
+        onSettle={ ( value, valuePrev ) => {
           dispatch( {
             type: 'History/Push',
             description: 'Change Fx Length',
@@ -43,8 +45,8 @@ const InspectorCurveFx = ( props: InspectorCurveFxProps ): JSX.Element | null =>
                 type: 'curve/moveFx',
                 curveId: props.curveId,
                 fx: fx.$id,
-                time,
-                timePrev
+                time: displayToTime( value ),
+                timePrev: displayToTime( valuePrev ),
               }
             ]
           } );
@@ -54,9 +56,9 @@ const InspectorCurveFx = ( props: InspectorCurveFxProps ): JSX.Element | null =>
     <InspectorItem name="Length">
       <NumberParam
         type="float"
-        value={ fx.length }
-        onChange={ ( value ) => { curve.resizeFx( fx.$id, value ); } }
-        onSettle={ ( length, lengthPrev ) => {
+        value={ timeToDisplay( fx.length ) }
+        onChange={ ( value ) => { curve.resizeFx( fx.$id, displayToTime( value ) ); } }
+        onSettle={ ( value, valuePrev ) => {
           dispatch( {
             type: 'History/Push',
             description: 'Change Fx Length',
@@ -65,8 +67,8 @@ const InspectorCurveFx = ( props: InspectorCurveFxProps ): JSX.Element | null =>
                 type: 'curve/resizeFx',
                 curveId: props.curveId,
                 fx: fx.$id,
-                length,
-                lengthPrev
+                length: displayToTime( value ),
+                lengthPrev: displayToTime( valuePrev ),
               }
             ]
           } );

--- a/packages/automaton-with-gui/src/view/components/InspectorCurveNode.tsx
+++ b/packages/automaton-with-gui/src/view/components/InspectorCurveNode.tsx
@@ -3,6 +3,7 @@ import { InspectorHr } from './InspectorHr';
 import { InspectorItem } from './InspectorItem';
 import { NumberParam } from './NumberParam';
 import { useDispatch, useSelector } from '../states/store';
+import { useTimeUnit } from '../utils/useTimeUnit';
 import React from 'react';
 
 // == compoennt ====================================================================================
@@ -19,6 +20,7 @@ const InspectorCurveNode = ( props: Props ): JSX.Element | null => {
   } ) );
   const curve = automaton?.getCurveById( props.curveId ) || null;
   const node = curves[ props.curveId ].nodes[ props.node ];
+  const { displayToTime, timeToDisplay } = useTimeUnit();
 
   return ( curve && <>
     <InspectorHeader text="Node" />
@@ -28,9 +30,9 @@ const InspectorCurveNode = ( props: Props ): JSX.Element | null => {
     <InspectorItem name="Time">
       <NumberParam
         type="float"
-        value={ node.time }
-        onChange={ ( time ) => { curve.moveNodeTime( node.$id, time ); } }
-        onSettle={ ( time, timePrev ) => {
+        value={ timeToDisplay( node.time ) }
+        onChange={ ( time ) => { curve.moveNodeTime( node.$id, displayToTime( time ) ); } }
+        onSettle={ ( value, valuePrev ) => {
           dispatch( {
             type: 'History/Push',
             description: 'Change Node Time',
@@ -39,8 +41,8 @@ const InspectorCurveNode = ( props: Props ): JSX.Element | null => {
                 type: 'curve/moveNodeTime',
                 curveId: props.curveId,
                 node: node.$id,
-                time,
-                timePrev
+                time: displayToTime( value ),
+                timePrev: displayToTime( valuePrev ),
               }
             ]
           } );
@@ -62,7 +64,7 @@ const InspectorCurveNode = ( props: Props ): JSX.Element | null => {
                 curveId: props.curveId,
                 node: node.$id,
                 value,
-                valuePrev
+                valuePrev,
               }
             ]
           } );
@@ -75,9 +77,9 @@ const InspectorCurveNode = ( props: Props ): JSX.Element | null => {
     <InspectorItem name="In Time">
       <NumberParam
         type="float"
-        value={ node.in?.time || 0.0 }
-        onChange={ ( value ) => { curve.moveHandleTime( node.$id, 'in', value ); } }
-        onSettle={ ( time, timePrev ) => {
+        value={ timeToDisplay( node.in?.time ?? 0.0 ) }
+        onChange={ ( value ) => { curve.moveHandleTime( node.$id, 'in', displayToTime( value ) ); } }
+        onSettle={ ( value, valuePrev ) => {
           dispatch( {
             type: 'History/Push',
             description: 'Change Node Handle Time',
@@ -87,8 +89,8 @@ const InspectorCurveNode = ( props: Props ): JSX.Element | null => {
                 curveId: props.curveId,
                 node: node.$id,
                 dir: 'in',
-                time,
-                timePrev
+                time: displayToTime( value ),
+                timePrev: displayToTime( valuePrev ),
               }
             ]
           } );
@@ -98,7 +100,7 @@ const InspectorCurveNode = ( props: Props ): JSX.Element | null => {
     <InspectorItem name="In Value">
       <NumberParam
         type="float"
-        value={ node.in?.value || 0.0 }
+        value={ node.in?.value ?? 0.0 }
         onChange={ ( value ) => { curve.moveHandleValue( node.$id, 'in', value ); } }
         onSettle={ ( value, valuePrev ) => {
           dispatch( {
@@ -111,7 +113,7 @@ const InspectorCurveNode = ( props: Props ): JSX.Element | null => {
                 node: node.$id,
                 dir: 'in',
                 value,
-                valuePrev
+                valuePrev,
               }
             ]
           } );
@@ -124,9 +126,9 @@ const InspectorCurveNode = ( props: Props ): JSX.Element | null => {
     <InspectorItem name="Out Time">
       <NumberParam
         type="float"
-        value={ node.out?.time || 0.0 }
-        onChange={ ( value ) => { curve.moveHandleTime( node.$id, 'out', value ); } }
-        onSettle={ ( time, timePrev ) => {
+        value={ timeToDisplay( node.out?.time ?? 0.0 ) }
+        onChange={ ( value ) => { curve.moveHandleTime( node.$id, 'out', displayToTime( value ) ); } }
+        onSettle={ ( value, valuePrev ) => {
           dispatch( {
             type: 'History/Push',
             description: 'Change Node Handle Time',
@@ -136,8 +138,8 @@ const InspectorCurveNode = ( props: Props ): JSX.Element | null => {
                 curveId: props.curveId,
                 node: node.$id,
                 dir: 'out',
-                time,
-                timePrev
+                time: displayToTime( value ),
+                timePrev: displayToTime( valuePrev ),
               }
             ]
           } );
@@ -147,7 +149,7 @@ const InspectorCurveNode = ( props: Props ): JSX.Element | null => {
     <InspectorItem name="Out Value">
       <NumberParam
         type="float"
-        value={ node.out?.value || 0.0 }
+        value={ node.out?.value ?? 0.0 }
         onChange={ ( value ) => { curve.moveHandleValue( node.$id, 'out', value ); } }
         onSettle={ ( value, valuePrev ) => {
           dispatch( {
@@ -160,7 +162,7 @@ const InspectorCurveNode = ( props: Props ): JSX.Element | null => {
                 node: node.$id,
                 dir: 'out',
                 value,
-                valuePrev
+                valuePrev,
               }
             ]
           } );

--- a/packages/automaton-with-gui/src/view/components/InspectorSnapping.tsx
+++ b/packages/automaton-with-gui/src/view/components/InspectorSnapping.tsx
@@ -58,7 +58,10 @@ const InspectorSnapping = (): JSX.Element | null => {
 
     <InspectorHr />
 
-    <InspectorItem name="Beat">
+    <InspectorItem
+      name="Beat Snap"
+      description="Make items snap to the beat."
+    >
       <BoolParam
         value={ guiSettings.snapBeatActive }
         onChange={ ( value ) => {
@@ -66,7 +69,10 @@ const InspectorSnapping = (): JSX.Element | null => {
         } }
       />
     </InspectorItem>
-    <InspectorItem name="BPM">
+    <InspectorItem
+      name="BPM"
+      description="Beat per minute of the song."
+    >
       <NumberParam
         type="float"
         value={ guiSettings.snapBeatBPM }
@@ -76,8 +82,8 @@ const InspectorSnapping = (): JSX.Element | null => {
       />
     </InspectorItem>
     <InspectorItem
-      name="Use Beat"
-      data-stalker="Show beat instead of time in GUI."
+      name="Use Beat in GUI"
+      description="Show beat instead of time in GUI."
     >
       <BoolParam
         value={ guiSettings.useBeatInGUI }

--- a/packages/automaton-with-gui/src/view/components/InspectorSnapping.tsx
+++ b/packages/automaton-with-gui/src/view/components/InspectorSnapping.tsx
@@ -69,29 +69,6 @@ const InspectorSnapping = (): JSX.Element | null => {
         } }
       />
     </InspectorItem>
-    <InspectorItem
-      name="BPM"
-      description="Beat per minute of the song."
-    >
-      <NumberParam
-        type="float"
-        value={ guiSettings.snapBeatBPM }
-        onChange={ ( value ) => {
-          automaton.setGUISettings( 'snapBeatBPM', Math.max( 0.0, value ) );
-        } }
-      />
-    </InspectorItem>
-    <InspectorItem
-      name="Use Beat in GUI"
-      description="Show beat instead of time in GUI."
-    >
-      <BoolParam
-        value={ guiSettings.useBeatInGUI }
-        onChange={ ( value ) => {
-          automaton.setGUISettings( 'useBeatInGUI', value );
-        } }
-      />
-    </InspectorItem>
   </> ) ?? null;
 };
 

--- a/packages/automaton-with-gui/src/view/components/InspectorSnapping.tsx
+++ b/packages/automaton-with-gui/src/view/components/InspectorSnapping.tsx
@@ -75,6 +75,17 @@ const InspectorSnapping = (): JSX.Element | null => {
         } }
       />
     </InspectorItem>
+    <InspectorItem
+      name="Use Beat"
+      data-stalker="Show beat instead of time in GUI."
+    >
+      <BoolParam
+        value={ guiSettings.useBeatInGUI }
+        onChange={ ( value ) => {
+          automaton.setGUISettings( 'useBeatInGUI', value );
+        } }
+      />
+    </InspectorItem>
   </> ) ?? null;
 };
 

--- a/packages/automaton-with-gui/src/view/icons/Icons.ts
+++ b/packages/automaton-with-gui/src/view/icons/Icons.ts
@@ -1,5 +1,6 @@
 import Automaton from './automaton.svg';
 import AutomatonA from './automaton-a.svg';
+import Beat from './beat.svg';
 import Channel from './channel.svg';
 import Close from './close.svg';
 import Cog from './cog.svg';
@@ -20,6 +21,7 @@ import Warning from './warning.svg';
 export const Icons = {
   Automaton,
   AutomatonA,
+  Beat,
   Channel,
   Close,
   Cog,

--- a/packages/automaton-with-gui/src/view/icons/beat.svg
+++ b/packages/automaton-with-gui/src/view/icons/beat.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <g transform="matrix(1,0,0,1,0.5,0)">
+        <path d="M11.5,3L19,3L19,7L15,7L15,16.5C15,19.536 12.536,22 9.5,22C6.464,22 4,19.536 4,16.5C4,13.464 6.464,11 9.5,11C10.205,11 10.88,11.133 11.5,11.376L11.5,3Z"/>
+    </g>
+</svg>

--- a/packages/automaton-with-gui/src/view/states/Settings.ts
+++ b/packages/automaton-with-gui/src/view/states/Settings.ts
@@ -2,7 +2,7 @@ import { Reducer } from 'redux';
 import { produce } from 'immer';
 
 // == state ========================================================================================
-type SettingsMode = 'none' | 'snapping' | 'general';
+type SettingsMode = 'none' | 'snapping' | 'beat' | 'general';
 
 export interface State {
   mode: SettingsMode;

--- a/packages/automaton-with-gui/src/view/utils/useTimeUnit.ts
+++ b/packages/automaton-with-gui/src/view/utils/useTimeUnit.ts
@@ -1,0 +1,60 @@
+import { useCallback } from 'react';
+import { useSelector } from '../states/store';
+
+export function useTimeUnit(): {
+  beatToTime: ( beat: number, isAbsolute?: boolean ) => number,
+  timeToBeat: ( time: number, isAbsolute?: boolean ) => number,
+  displayToTime: ( value: number, isAbsolute?: boolean ) => number,
+  timeToDisplay: ( time: number, isAbsolute?: boolean ) => number,
+} {
+  const {
+    snapBeatBPM,
+    useBeatInGUI,
+  } = useSelector( ( state ) => ( {
+    snapBeatBPM: state.automaton.guiSettings.snapBeatBPM,
+    useBeatInGUI: state.automaton.guiSettings.useBeatInGUI,
+  } ) );
+
+  const beatToTime = useCallback(
+    ( beat: number, isAbsolute = false ): number => {
+      return beat / snapBeatBPM * 60.0;
+    },
+    [ snapBeatBPM ]
+  );
+
+  const timeToBeat = useCallback(
+    ( time: number, isAbsolute = false ): number => {
+      return time * snapBeatBPM / 60.0;
+    },
+    [ snapBeatBPM ]
+  );
+
+  const displayToTime = useCallback(
+    ( value: number, isAbsolute = false ): number => {
+      if ( useBeatInGUI ) {
+        return beatToTime( value );
+      } else {
+        return value;
+      }
+    },
+    [ beatToTime, useBeatInGUI ]
+  );
+
+  const timeToDisplay = useCallback(
+    ( time: number, isAbsolute = false ): number => {
+      if ( useBeatInGUI ) {
+        return timeToBeat( time );
+      } else {
+        return time;
+      }
+    },
+    [ timeToBeat, useBeatInGUI ]
+  );
+
+  return {
+    beatToTime,
+    timeToBeat,
+    displayToTime,
+    timeToDisplay,
+  };
+}


### PR DESCRIPTION
will close #85 

- ✨ `gui` New GUI option: `useBeatInGUI`
    - Show and set beat instead of time in Header and Inspector
    - Can be toggled via new beat settings
- 💡 Move some setting properties into a new beat menu
- 💡 Trivial UI improvements
- 💻 `gui` Trivial, remove a circular dependency
