### PR TITLE
fix: modify exports of package.json

### DIFF
--- a/packages/automaton-fxs-v2compat/package.json
+++ b/packages/automaton-fxs-v2compat/package.json
@@ -9,12 +9,15 @@
   "exports": {
     "import": {
       "development": "./dist/automaton-fxs-v2compat.module.js",
-      "production": "./dist/automaton-fxs-v2compat.module.min.js"
+      "production": "./dist/automaton-fxs-v2compat.module.min.js",
+      "default": "./dist/automaton-fxs-v2compat.module.min.js"
     },
     "require": {
       "development": "./dist/automaton-fxs-v2compat.js",
-      "production": "./dist/automaton-fxs-v2compat.min.js"
-    }
+      "production": "./dist/automaton-fxs-v2compat.min.js",
+      "default": "./dist/automaton-fxs-v2compat.min.js"
+    },
+    "default": "./dist/automaton-fxs-v2compat.min.js"
   },
   "types": "types/index.d.ts",
   "typesVersions": {

--- a/packages/automaton-fxs/package.json
+++ b/packages/automaton-fxs/package.json
@@ -9,12 +9,15 @@
   "exports": {
     "import": {
       "development": "./dist/automaton-fxs.module.js",
-      "production": "./dist/automaton-fxs.module.min.js"
+      "production": "./dist/automaton-fxs.module.min.js",
+      "default": "./dist/automaton-fxs.module.min.js"
     },
     "require": {
       "development": "./dist/automaton-fxs.js",
-      "production": "./dist/automaton-fxs.min.js"
-    }
+      "production": "./dist/automaton-fxs.min.js",
+      "default": "./dist/automaton-fxs.min.js"
+    },
+    "default": "./dist/automaton-with-gui.min.js"
   },
   "types": "types/index.d.ts",
   "typesVersions": {

--- a/packages/automaton-with-gui/package.json
+++ b/packages/automaton-with-gui/package.json
@@ -9,12 +9,15 @@
   "exports": {
     "import": {
       "development": "./dist/automaton-with-gui.module.js",
-      "production": "./dist/automaton-with-gui.module.min.js"
+      "production": "./dist/automaton-with-gui.module.min.js",
+      "default": "./dist/automaton-with-gui.module.min.js"
     },
     "require": {
       "development": "./dist/automaton-with-gui.js",
-      "production": "./dist/automaton-with-gui.min.js"
-    }
+      "production": "./dist/automaton-with-gui.min.js",
+      "default": "./dist/automaton-with-gui.min.js"
+    },
+    "default": "./dist/automaton-with-gui.min.js"
   },
   "types": "types/index.d.ts",
   "typesVersions": {

--- a/packages/automaton/package.json
+++ b/packages/automaton/package.json
@@ -9,12 +9,15 @@
   "exports": {
     "import": {
       "development": "./dist/automaton.module.js",
-      "production": "./dist/automaton.module.min.js"
+      "production": "./dist/automaton.module.min.js",
+      "default": "./dist/automaton.module.min.js"
     },
     "require": {
       "development": "./dist/automaton.js",
-      "production": "./dist/automaton.min.js"
-    }
+      "production": "./dist/automaton.min.js",
+      "default": "./dist/automaton.min.js"
+    },
+    "default": "./dist/automaton-with-gui.min.js"
   },
   "types": "types/index.d.ts",
   "typesVersions": {


### PR DESCRIPTION
javascript is hard

It seems node.js does not recognize the previous notation of `"exports"` ......
The `"default"` exports will help. Added them.

https://webpack.js.org/guides/package-exports/
