### PR TITLE
chore: NODE_ENV is still important

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@types/jest": "^26.0.10",
     "@typescript-eslint/eslint-plugin": "^4.7.0",
     "@typescript-eslint/parser": "^4.7.0",
+    "cross-env": "^7.0.2",
     "downlevel-dts": "^0.7.0",
     "eslint": "^7.7.0",
     "eslint-plugin-jest": "^24.1.3",

--- a/packages/automaton-fxs-v2compat/package.json
+++ b/packages/automaton-fxs-v2compat/package.json
@@ -35,8 +35,8 @@
     "clean": "rimraf dist/ ts*/ types/",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "build": "yarn build-dev && yarn build-prod && yarn build-types",
-    "build-dev": "rollup -c --environment NODE_ENV:development",
-    "build-prod": "rollup -c --environment NODE_ENV:production",
+    "build-dev": "cross-env NODE_ENV=development rollup -c",
+    "build-prod": "cross-env NODE_ENV=production rollup -c",
     "build-types": "tsc --declaration --declarationDir ./types --emitDeclarationOnly && downlevel-dts types ts3.4/types"
   },
   "files": [

--- a/packages/automaton-fxs-v2compat/package.json
+++ b/packages/automaton-fxs-v2compat/package.json
@@ -29,13 +29,14 @@
   },
   "license": "MIT",
   "scripts": {
-    "dev": "rollup -w -c",
+    "dev": "rollup -w -c --environment NODE_ENV:development",
     "all": "yarn && yarn lint && yarn clean && yarn build",
     "version": "yarn all",
     "clean": "rimraf dist/ ts*/ types/",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
-    "build": "yarn build-dist && yarn build-types",
-    "build-dist": "rollup -c",
+    "build": "yarn build-dev && yarn build-prod && yarn build-types",
+    "build-dev": "rollup -c --environment NODE_ENV:development",
+    "build-prod": "rollup -c --environment NODE_ENV:production",
     "build-types": "tsc --declaration --declarationDir ./types --emitDeclarationOnly && downlevel-dts types ts3.4/types"
   },
   "files": [

--- a/packages/automaton-fxs-v2compat/rollup.config.js
+++ b/packages/automaton-fxs-v2compat/rollup.config.js
@@ -11,9 +11,10 @@ const copyright = '(c) 2017-2020 FMS_Cat';
 const licenseName = 'MIT License';
 const licenseUri = 'https://github.com/FMS-Cat/automaton/blob/master/LICENSE';
 const globalName = 'AUTOMATON_FXS_V2COMPAT';
-const filename = 'automaton-fxs-v2compat';
+const filename = 'dist/automaton-fxs-v2compat';
 
 // == envs =========================================================================================
+const DEV = process.env.NODE_ENV === 'development';
 const WATCH = process.env.ROLLUP_WATCH === 'true';
 
 // == banner =======================================================================================
@@ -34,15 +35,20 @@ const serveOptions = {
 };
 
 // == config =======================================================================================
-function createOutputOptions( { file, dev, esm } ) {
+function createOutputOptions( { esm } ) {
+  let file = filename;
+  file += esm ? '.module' : '';
+  file += DEV ? '' : '.min';
+  file += '.js';
+
   return {
     file,
     format: esm ? 'esm' : 'umd',
     name: esm ? undefined : globalName,
-    banner: dev ? bannerTextDev : bannerTextProd,
-    sourcemap: dev ? 'inline' : false,
+    banner: DEV ? bannerTextDev : bannerTextProd,
+    sourcemap: DEV ? 'inline' : false,
     plugins: [
-      ...( dev ? [] : [
+      ...( DEV ? [] : [
         terser(),
       ] ),
       ...( WATCH ? [
@@ -52,7 +58,7 @@ function createOutputOptions( { file, dev, esm } ) {
   };
 }
 
-function createConfig( output, { dev } ) {
+function createConfig( output ) {
   return {
     input: 'src/index.ts',
     output,
@@ -60,7 +66,7 @@ function createConfig( output, { dev } ) {
       typescript(),
       replace( {
         'process.env.VERSION': `'${ packageJson.version }'`,
-        'process.env.DEV': `'${ dev }'`,
+        'process.env.DEV': `'${ DEV }'`,
       } ),
     ],
   };
@@ -69,17 +75,13 @@ function createConfig( output, { dev } ) {
 // == output =======================================================================================
 const buildConfig = [
   createConfig( [
-    createOutputOptions( { file: `dist/${ filename }.js`, dev: true } ),
-    createOutputOptions( { file: `dist/${ filename }.module.js`, dev: true, esm: true } ),
-  ], { dev: true } ),
-  createConfig( [
-    createOutputOptions( { file: `dist/${ filename }.min.js` } ),
-    createOutputOptions( { file: `dist/${ filename }.module.min.js`, esm: true } ),
-  ], { dev: false } ),
+    createOutputOptions( {} ),
+    createOutputOptions( { esm: true } ),
+  ] ),
 ];
 
 const watchConfig = createConfig( [
-  createOutputOptions( { file: `dist/${ filename }.module.js`, dev: true, esm: true } ),
-], { dev: true } );
+  createOutputOptions( { esm: true } ),
+] );
 
 export default WATCH ? watchConfig : buildConfig;

--- a/packages/automaton-fxs-v2compat/rollup.config.js
+++ b/packages/automaton-fxs-v2compat/rollup.config.js
@@ -66,7 +66,7 @@ function createConfig( output ) {
       typescript(),
       replace( {
         'process.env.VERSION': `'${ packageJson.version }'`,
-        'process.env.DEV': `'${ DEV }'`,
+        'process.env.NODE_ENV': `'${ process.env.NODE_ENV }'`,
       } ),
     ],
   };

--- a/packages/automaton-fxs/package.json
+++ b/packages/automaton-fxs/package.json
@@ -29,14 +29,15 @@
   },
   "license": "MIT",
   "scripts": {
-    "dev": "rollup -w -c",
+    "dev": "rollup -w -c --environment NODE_ENV:development",
     "all": "yarn && yarn lint && yarn test && yarn clean && yarn build",
     "version": "yarn all",
     "clean": "rimraf dist/ ts*/ types/",
     "test": "jest",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
-    "build": "yarn build-dist && yarn build-types",
-    "build-dist": "rollup -c",
+    "build": "yarn build-dev && yarn build-prod && yarn build-types",
+    "build-dev": "rollup -c --environment NODE_ENV:development",
+    "build-prod": "rollup -c --environment NODE_ENV:production",
     "build-types": "tsc --declaration --declarationDir ./types --emitDeclarationOnly && downlevel-dts types ts3.4/types"
   },
   "files": [

--- a/packages/automaton-fxs/package.json
+++ b/packages/automaton-fxs/package.json
@@ -36,8 +36,8 @@
     "test": "jest",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "build": "yarn build-dev && yarn build-prod && yarn build-types",
-    "build-dev": "rollup -c --environment NODE_ENV:development",
-    "build-prod": "rollup -c --environment NODE_ENV:production",
+    "build-dev": "cross-env NODE_ENV=development rollup -c",
+    "build-prod": "cross-env NODE_ENV=production rollup -c",
     "build-types": "tsc --declaration --declarationDir ./types --emitDeclarationOnly && downlevel-dts types ts3.4/types"
   },
   "files": [

--- a/packages/automaton-fxs/rollup.config.js
+++ b/packages/automaton-fxs/rollup.config.js
@@ -11,9 +11,10 @@ const copyright = '(c) 2017-2020 FMS_Cat';
 const licenseName = 'MIT License';
 const licenseUri = 'https://github.com/FMS-Cat/automaton/blob/master/LICENSE';
 const globalName = 'AUTOMATON_FXS';
-const filename = 'automaton-fxs';
+const filename = 'dev/automaton-fxs';
 
 // == envs =========================================================================================
+const DEV = process.env.NODE_ENV === 'development';
 const WATCH = process.env.ROLLUP_WATCH === 'true';
 
 // == banner =======================================================================================
@@ -34,15 +35,20 @@ const serveOptions = {
 };
 
 // == config =======================================================================================
-function createOutputOptions( { file, dev, esm } ) {
+function createOutputOptions( { esm } ) {
+  let file = filename;
+  file += esm ? '.module' : '';
+  file += DEV ? '' : '.min';
+  file += '.js';
+
   return {
     file,
     format: esm ? 'esm' : 'umd',
     name: esm ? undefined : globalName,
-    banner: dev ? bannerTextDev : bannerTextProd,
-    sourcemap: dev ? 'inline' : false,
+    banner: DEV ? bannerTextDev : bannerTextProd,
+    sourcemap: DEV ? 'inline' : false,
     plugins: [
-      ...( dev ? [] : [
+      ...( DEV ? [] : [
         terser(),
       ] ),
       ...( WATCH ? [
@@ -52,7 +58,7 @@ function createOutputOptions( { file, dev, esm } ) {
   };
 }
 
-function createConfig( output, { dev } ) {
+function createConfig( output ) {
   return {
     input: 'src/index.ts',
     output,
@@ -60,7 +66,7 @@ function createConfig( output, { dev } ) {
       typescript(),
       replace( {
         'process.env.VERSION': `'${ packageJson.version }'`,
-        'process.env.DEV': `'${ dev }'`,
+        'process.env.DEV': `'${ DEV }'`,
       } ),
     ],
   };
@@ -69,17 +75,13 @@ function createConfig( output, { dev } ) {
 // == output =======================================================================================
 const buildConfig = [
   createConfig( [
-    createOutputOptions( { file: `dist/${ filename }.js`, dev: true } ),
-    createOutputOptions( { file: `dist/${ filename }.module.js`, dev: true, esm: true } ),
-  ], { dev: true } ),
-  createConfig( [
-    createOutputOptions( { file: `dist/${ filename }.min.js` } ),
-    createOutputOptions( { file: `dist/${ filename }.module.min.js`, esm: true } ),
-  ], { dev: false } ),
+    createOutputOptions( {} ),
+    createOutputOptions( { esm: true } ),
+  ] ),
 ];
 
 const watchConfig = createConfig( [
-  createOutputOptions( { file: `dist/${ filename }.module.js`, dev: true, esm: true } ),
-], { dev: true } );
+  createOutputOptions( { esm: true } ),
+] );
 
 export default WATCH ? watchConfig : buildConfig;

--- a/packages/automaton-fxs/rollup.config.js
+++ b/packages/automaton-fxs/rollup.config.js
@@ -66,7 +66,7 @@ function createConfig( output ) {
       typescript(),
       replace( {
         'process.env.VERSION': `'${ packageJson.version }'`,
-        'process.env.DEV': `'${ DEV }'`,
+        'process.env.NODE_ENV': `'${ process.env.NODE_ENV }'`,
       } ),
     ],
   };

--- a/packages/automaton-with-gui/package.json
+++ b/packages/automaton-with-gui/package.json
@@ -30,14 +30,15 @@
   "sideEffects": false,
   "license": "MIT",
   "scripts": {
-    "dev": "rollup -w -c",
+    "dev": "rollup -w -c --environment NODE_ENV:development",
     "all": "yarn && yarn lint && yarn test && yarn clean && yarn build && yarn docs",
     "version": "yarn all",
     "clean": "rimraf dist/ docs/ ts*/ types/",
     "test": "jest",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
-    "build": "yarn build-dist && yarn build-types",
-    "build-dist": "rollup -c",
+    "build": "yarn build-dev && yarn build-prod && yarn build-types",
+    "build-dev": "rollup -c --environment NODE_ENV:development",
+    "build-prod": "rollup -c --environment NODE_ENV:production",
     "build-types": "tsc --declaration --declarationDir ./types --emitDeclarationOnly && downlevel-dts types ts3.4/types",
     "docs": "typedoc --out docs --mode file --excludeNotExported"
   },

--- a/packages/automaton-with-gui/package.json
+++ b/packages/automaton-with-gui/package.json
@@ -37,8 +37,8 @@
     "test": "jest",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "build": "yarn build-dev && yarn build-prod && yarn build-types",
-    "build-dev": "rollup -c --environment NODE_ENV:development",
-    "build-prod": "rollup -c --environment NODE_ENV:production",
+    "build-dev": "cross-env NODE_ENV=development rollup -c",
+    "build-prod": "cross-env NODE_ENV=production rollup -c",
     "build-types": "tsc --declaration --declarationDir ./types --emitDeclarationOnly && downlevel-dts types ts3.4/types",
     "docs": "typedoc --out docs --mode file --excludeNotExported"
   },

--- a/packages/automaton-with-gui/rollup.config.js
+++ b/packages/automaton-with-gui/rollup.config.js
@@ -69,7 +69,7 @@ function createConfig( output ) {
       typescript(),
       replace( {
         'process.env.VERSION': `'${ packageJson.version }'`,
-        'process.env.DEV': `'${ DEV }'`,
+        'process.env.NODE_ENV': `'${ process.env.NODE_ENV }'`,
       } ),
       resolve(),
       commonjs(),

--- a/packages/automaton-with-gui/rollup.config.js
+++ b/packages/automaton-with-gui/rollup.config.js
@@ -14,9 +14,10 @@ const copyright = '(c) 2017-2020 FMS_Cat';
 const licenseName = 'MIT License';
 const licenseUri = 'https://github.com/FMS-Cat/automaton/blob/master/LICENSE';
 const globalName = 'AUTOMATON_WITH_GUI';
-const filename = 'automaton-with-gui';
+const filename = 'dist/automaton-with-gui';
 
 // == envs =========================================================================================
+const DEV = process.env.NODE_ENV === 'development';
 const WATCH = process.env.ROLLUP_WATCH === 'true';
 
 // == banner =======================================================================================
@@ -37,15 +38,20 @@ const serveOptions = {
 };
 
 // == config =======================================================================================
-function createOutputOptions( { file, dev, esm } ) {
+function createOutputOptions( { esm } ) {
+  let file = filename;
+  file += esm ? '.module' : '';
+  file += DEV ? '' : '.min';
+  file += '.js';
+
   return {
     file,
     format: esm ? 'esm' : 'umd',
     name: esm ? undefined : globalName,
-    banner: dev ? bannerTextDev : bannerTextProd,
-    sourcemap: dev ? 'inline' : false,
+    banner: DEV ? bannerTextDev : bannerTextProd,
+    sourcemap: DEV ? 'inline' : false,
     plugins: [
-      ...( dev ? [] : [
+      ...( DEV ? [] : [
         terser(),
       ] ),
       ...( WATCH ? [
@@ -63,7 +69,7 @@ function createConfig( output ) {
       typescript(),
       replace( {
         'process.env.VERSION': `'${ packageJson.version }'`,
-        // 'process.env.DEV': `'${ dev }'`,
+        'process.env.DEV': `'${ DEV }'`,
       } ),
       resolve(),
       commonjs(),
@@ -75,15 +81,13 @@ function createConfig( output ) {
 // == output =======================================================================================
 const buildConfig = [
   createConfig( [
-    createOutputOptions( { file: `dist/${ filename }.js`, dev: true } ),
-    createOutputOptions( { file: `dist/${ filename }.module.js`, dev: true, esm: true } ),
-    createOutputOptions( { file: `dist/${ filename }.min.js` } ),
-    createOutputOptions( { file: `dist/${ filename }.module.min.js`, esm: true } ),
+    createOutputOptions( {} ),
+    createOutputOptions( { esm: true } ),
   ] ),
 ];
 
 const watchConfig = createConfig( [
-  createOutputOptions( { file: `dist/${ filename }.module.js`, dev: true, esm: true } ),
+  createOutputOptions( { esm: true } ),
 ] );
 
 export default WATCH ? watchConfig : buildConfig;

--- a/packages/automaton/package.json
+++ b/packages/automaton/package.json
@@ -36,8 +36,8 @@
     "test": "jest",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "build": "yarn build-dev && yarn build-prod && yarn build-types",
-    "build-dev": "rollup -c --environment NODE_ENV:development",
-    "build-prod": "rollup -c --environment NODE_ENV:production",
+    "build-dev": "cross-env NODE_ENV=development rollup -c",
+    "build-prod": "cross-env NODE_ENV=production rollup -c",
     "build-types": "tsc --declaration --declarationDir ./types --emitDeclarationOnly && downlevel-dts types ts3.4/types",
     "docs": "typedoc --out docs --mode file --excludeNotExported"
   },

--- a/packages/automaton/package.json
+++ b/packages/automaton/package.json
@@ -29,14 +29,15 @@
   },
   "license": "MIT",
   "scripts": {
-    "dev": "rollup -w -c",
+    "dev": "rollup -w -c --environment NODE_ENV:development",
     "all": "yarn && yarn lint && yarn test && yarn clean && yarn build && yarn docs",
     "version": "yarn all",
     "clean": "rimraf dist/ docs/ ts*/ types/",
     "test": "jest",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
-    "build": "yarn build-dist && yarn build-types",
-    "build-dist": "rollup -c",
+    "build": "yarn build-dev && yarn build-prod && yarn build-types",
+    "build-dev": "rollup -c --environment NODE_ENV:development",
+    "build-prod": "rollup -c --environment NODE_ENV:production",
     "build-types": "tsc --declaration --declarationDir ./types --emitDeclarationOnly && downlevel-dts types ts3.4/types",
     "docs": "typedoc --out docs --mode file --excludeNotExported"
   },

--- a/packages/automaton/rollup.config.js
+++ b/packages/automaton/rollup.config.js
@@ -11,9 +11,10 @@ const copyright = '(c) 2017-2020 FMS_Cat';
 const licenseName = 'MIT License';
 const licenseUri = 'https://github.com/FMS-Cat/automaton/blob/master/LICENSE';
 const globalName = 'AUTOMATON';
-const filename = 'automaton';
+const filename = 'dist/automaton';
 
 // == envs =========================================================================================
+const DEV = process.env.NODE_ENV === 'development';
 const WATCH = process.env.ROLLUP_WATCH === 'true';
 
 // == banner =======================================================================================
@@ -34,15 +35,20 @@ const serveOptions = {
 };
 
 // == config =======================================================================================
-function createOutputOptions( { file, dev, esm } ) {
+function createOutputOptions( { esm } ) {
+  let file = filename;
+  file += esm ? '.module' : '';
+  file += DEV ? '' : '.min';
+  file += '.js';
+
   return {
     file,
     format: esm ? 'esm' : 'umd',
     name: esm ? undefined : globalName,
-    banner: dev ? bannerTextDev : bannerTextProd,
-    sourcemap: dev ? 'inline' : false,
+    banner: DEV ? bannerTextDev : bannerTextProd,
+    sourcemap: DEV ? 'inline' : false,
     plugins: [
-      ...( dev ? [] : [
+      ...( DEV ? [] : [
         terser(),
       ] ),
       ...( WATCH ? [
@@ -52,7 +58,7 @@ function createOutputOptions( { file, dev, esm } ) {
   };
 }
 
-function createConfig( output, { dev } ) {
+function createConfig( output ) {
   return {
     input: 'src/index.ts',
     output,
@@ -60,7 +66,7 @@ function createConfig( output, { dev } ) {
       typescript(),
       replace( {
         'process.env.VERSION': `'${ packageJson.version }'`,
-        'process.env.DEV': `'${ dev }'`,
+        'process.env.DEV': `'${ DEV }'`,
       } ),
     ],
   };
@@ -69,17 +75,13 @@ function createConfig( output, { dev } ) {
 // == output =======================================================================================
 const buildConfig = [
   createConfig( [
-    createOutputOptions( { file: `dist/${ filename }.js`, dev: true } ),
-    createOutputOptions( { file: `dist/${ filename }.module.js`, dev: true, esm: true } ),
-  ], { dev: true } ),
-  createConfig( [
-    createOutputOptions( { file: `dist/${ filename }.min.js` } ),
-    createOutputOptions( { file: `dist/${ filename }.module.min.js`, esm: true } ),
-  ], { dev: false } ),
+    createOutputOptions( {} ),
+    createOutputOptions( { esm: true } ),
+  ] ),
 ];
 
 const watchConfig = createConfig( [
-  createOutputOptions( { file: `dist/${ filename }.module.js`, dev: true, esm: true } ),
-], { dev: true } );
+  createOutputOptions( { esm: true } ),
+] );
 
 export default WATCH ? watchConfig : buildConfig;

--- a/packages/automaton/rollup.config.js
+++ b/packages/automaton/rollup.config.js
@@ -66,7 +66,7 @@ function createConfig( output ) {
       typescript(),
       replace( {
         'process.env.VERSION': `'${ packageJson.version }'`,
-        'process.env.DEV': `'${ DEV }'`,
+        'process.env.NODE_ENV': `'${ process.env.NODE_ENV }'`,
       } ),
     ],
   };

--- a/packages/automaton/src/Automaton.ts
+++ b/packages/automaton/src/Automaton.ts
@@ -99,7 +99,7 @@ export class Automaton {
       ...data.channels.map( ( [ name, data ] ) => {
         const channel = new Channel( this, data );
 
-        if ( process.env.DEV ) {
+        if ( process.env.NODE_ENV === 'development' ) {
           if ( this.mapNameToChannel.has( name ) ) {
             console.warn( `Duplicated channel: ${ name }` );
           }
@@ -118,7 +118,7 @@ export class Automaton {
   public addFxDefinitions( fxDefinitions: { [ id: string ]: FxDefinition } ): void {
     Object.entries( fxDefinitions ).forEach( ( [ id, fxDef ] ) => {
       if ( typeof fxDef.func === 'function' ) { // ignore unrelated entries
-        if ( process.env.DEV ) {
+        if ( process.env.NODE_ENV === 'development' ) {
           if ( this.__fxDefinitions[ id ] != null ) {
             console.warn( `Overwriting the existing fx definition: ${ id }` );
           }
@@ -191,7 +191,7 @@ export class Automaton {
   ): number {
     const channel = this.mapNameToChannel.get( name );
 
-    if ( process.env.DEV ) {
+    if ( process.env.NODE_ENV === 'development' ) {
       if ( !channel ) {
         throw new Error( `No such channel: ${ name }` );
       }

--- a/packages/automaton/src/Curve.ts
+++ b/packages/automaton/src/Curve.ts
@@ -153,7 +153,7 @@ export class Curve {
       const fx = this.__fxs[ iFx ];
       const fxDef = this.__automaton.getFxDefinition( fx.def );
       if ( !fxDef ) {
-        if ( process.env.DEV ) {
+        if ( process.env.NODE_ENV === 'development' ) {
           console.warn( `No such fx definition: ${ fx.def }` );
         }
 
@@ -164,7 +164,7 @@ export class Curve {
       const i0 = Math.ceil( this.__automaton.resolution * fx.time );
       const i1 = Math.floor( this.__automaton.resolution * availableEnd );
       if ( i1 <= i0 ) {
-        if ( process.env.DEV ) {
+        if ( process.env.NODE_ENV === 'development' ) {
           console.error( 'Length of the fx section is being negative' );
         }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3574,6 +3574,13 @@ cosmiconfig@^7.0.0:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
+cross-env@^7.0.2:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -3585,7 +3592,7 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0, cross-spawn@^7.0.2:
+cross-spawn@^7.0.0, cross-spawn@^7.0.1, cross-spawn@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
It seems setting `NODE_ENV` is still important even in rollup considering how terser crushes `if (process.env.NODE_ENV) {` in external libraries