### PR TITLE
fix: automaton-with-gui is now okay to be imported from nodejs remove a code where it attempts to access global window

### DIFF
--- a/packages/automaton-with-gui/src/view/states/store.tsx
+++ b/packages/automaton-with-gui/src/view/states/store.tsx
@@ -63,8 +63,12 @@ const reducer = combineReducers<State>( {
 } );
 
 // == store ========================================================================================
-const devtools = ( window as any ).__REDUX_DEVTOOLS_EXTENSION__;
 export function createStore(): Store<State, Action> {
+  let devtools: any;
+  if ( typeof window !== 'undefined' ) { // vs. node.js
+    devtools = window && ( window as any ).__REDUX_DEVTOOLS_EXTENSION__;
+  }
+
   return createReduxStore(
     reducer,
     devtools && devtools()


### PR DESCRIPTION
remove a code where it attempts to access global window

### but why??

I wanted to use `AutomatonWithGUI.minimizeData` from nodejs......
