### PR TITLE
fix: SerializedBezierNode is now okay to not be a tuple

### DIFF
--- a/packages/automaton/src/types/SerializedBezierNode.ts
+++ b/packages/automaton/src/types/SerializedBezierNode.ts
@@ -38,4 +38,4 @@ export type SerializedBezierNode = [
    * `0.0` by default.
    */
   outValue?: number,
-];
+] | number[];


### PR DESCRIPTION
will resolve #121 

now it's able to grant json serialized data as a `SerializedAutomaton`
