### PR TITLE
fix: preserve class name when applying mixins

### DIFF
--- a/packages/automaton-with-gui/src/AutomatonWithGUI.tsx
+++ b/packages/automaton-with-gui/src/AutomatonWithGUI.tsx
@@ -59,6 +59,7 @@ export interface AutomatonWithGUIOptions extends AutomatonOptions {
 /**
  * IT'S AUTOMATON!
  */
+export interface AutomatonWithGUI extends EventEmittable<AutomatonWithGUIEvents> {}
 export class AutomatonWithGUI extends Automaton
   implements Serializable<SerializedAutomatonWithGUI> {
   /**
@@ -923,5 +924,4 @@ export interface AutomatonWithGUIEvents {
   setLoopRegion: { loopRegion: { begin: number; end: number } | null };
 }
 
-export interface AutomatonWithGUI extends EventEmittable<AutomatonWithGUIEvents> {}
 applyMixins( AutomatonWithGUI, [ EventEmittable ] );

--- a/packages/automaton-with-gui/src/ChannelItemWithGUI.ts
+++ b/packages/automaton-with-gui/src/ChannelItemWithGUI.ts
@@ -5,6 +5,7 @@ import { SerializableWithID } from './types/SerializableWithID';
 import { applyMixins } from './utils/applyMixins';
 import type { StateChannelItem } from './types/StateChannelItem';
 
+export interface ChannelItemWithGUI extends SerializableWithID<SerializedChannelItem> {}
 export class ChannelItemWithGUI extends ChannelItem {
   protected __automaton!: AutomatonWithGUI;
 
@@ -76,5 +77,4 @@ export class ChannelItemWithGUI extends ChannelItem {
   }
 }
 
-export interface ChannelItemWithGUI extends SerializableWithID<SerializedChannelItem> {}
 applyMixins( ChannelItemWithGUI, [ SerializableWithID ] );

--- a/packages/automaton-with-gui/src/ChannelWithGUI.ts
+++ b/packages/automaton-with-gui/src/ChannelWithGUI.ts
@@ -25,6 +25,8 @@ export enum ChannelStatusCode {
  * @param automaton Parent automaton
  * @param data Data of the channel
  */
+export interface ChannelWithGUI extends EventEmittable<ChannelWithGUIEvents> {}
+export interface ChannelWithGUI extends WithStatus<ChannelStatusCode> {}
 export class ChannelWithGUI extends Channel implements Serializable<SerializedChannel> {
   /**
    * The parent automaton.
@@ -684,6 +686,4 @@ export interface ChannelWithGUIEvents {
   changeLength: { length: number };
 }
 
-export interface ChannelWithGUI extends EventEmittable<ChannelWithGUIEvents> {}
-export interface ChannelWithGUI extends WithStatus<ChannelStatusCode> {}
 applyMixins( ChannelWithGUI, [ EventEmittable, WithStatus ] );

--- a/packages/automaton-with-gui/src/CurveWithGUI.ts
+++ b/packages/automaton-with-gui/src/CurveWithGUI.ts
@@ -32,6 +32,9 @@ export enum CurveStatusCode {
  * @param automaton Parent automaton
  * @param data Data of the channel
  */
+export interface CurveWithGUI extends SerializableWithID<SerializedCurve> {}
+export interface CurveWithGUI extends EventEmittable<CurveWithGUIEvents> {}
+export interface CurveWithGUI extends WithStatus<CurveStatusCode> {}
 export class CurveWithGUI extends Curve {
   /**
    * Default data of a curve.
@@ -971,7 +974,4 @@ export interface CurveWithGUIEvents {
   changeLength: { length: number };
 }
 
-export interface CurveWithGUI extends SerializableWithID<SerializedCurve> {}
-export interface CurveWithGUI extends EventEmittable<CurveWithGUIEvents> {}
-export interface CurveWithGUI extends WithStatus<CurveStatusCode> {}
 applyMixins( CurveWithGUI, [ SerializableWithID, EventEmittable, WithStatus ] );

--- a/packages/automaton-with-gui/src/GUIRemocon.ts
+++ b/packages/automaton-with-gui/src/GUIRemocon.ts
@@ -2,6 +2,7 @@ import { EventEmittable } from './mixins/EventEmittable';
 import { applyMixins } from './utils/applyMixins';
 import type { ToastyParams } from './types/ToastyParams';
 
+export interface GUIRemocon extends EventEmittable<GUIRemoconEvents> {}
 export class GUIRemocon {
   public undo(): void {
     this.__emit( 'undo' );
@@ -27,5 +28,4 @@ export interface GUIRemoconEvents {
   toasty: ToastyParams;
 }
 
-export interface GUIRemocon extends EventEmittable<GUIRemoconEvents> {}
 applyMixins( GUIRemocon, [ EventEmittable ] );

--- a/packages/automaton-with-gui/src/utils/applyMixins.ts
+++ b/packages/automaton-with-gui/src/utils/applyMixins.ts
@@ -1,11 +1,14 @@
 export function applyMixins( derivedCtor: any, baseCtors: any[] ): void {
   baseCtors.forEach( ( baseCtor ) => {
     Object.getOwnPropertyNames( baseCtor.prototype ).forEach( ( name ) => {
-      Object.defineProperty(
-        derivedCtor.prototype,
-        name,
-        Object.getOwnPropertyDescriptor( baseCtor.prototype, name )!
-      );
+      // we should not use constructor otherwise the class name will be changed
+      if ( name !== 'constructor' ) {
+        Object.defineProperty(
+          derivedCtor.prototype,
+          name,
+          Object.getOwnPropertyDescriptor( baseCtor.prototype, name )!
+        );
+      }
     } );
   } );
 }


### PR DESCRIPTION
kinda trivial

it seems I should not apply derived `constructor` s in `applyMixins` (see the diff of `applyMixins.ts`)
