### PR TITLE
The Resume API

### DIFF
--- a/packages/automaton-with-gui/playground-examples/demo.js
+++ b/packages/automaton-with-gui/playground-examples/demo.js
@@ -64,6 +64,9 @@ automaton.on( 'seek', ( event ) => {
   automaton.reset(); // we should call this when we modify the time
 } );
 
+// resume from the last time it closed, using Local Storage
+automaton.resume( 'demoResume' ); // specifies the local storage key
+
 // == components ===================================================================================
 function drawBackground() {
   context.save();

--- a/packages/automaton-with-gui/playground-examples/event.js
+++ b/packages/automaton-with-gui/playground-examples/event.js
@@ -49,6 +49,8 @@ automaton.on( 'seek', ( event ) => {
   automaton.reset();
 } );
 
+automaton.resume( 'eventResume' );
+
 // == particle system ==============================================================================
 const N_PARTICLES = 100;
 let particleHead = 0;

--- a/packages/automaton-with-gui/playground-examples/fx-definition.js
+++ b/packages/automaton-with-gui/playground-examples/fx-definition.js
@@ -110,6 +110,8 @@ automaton.on( 'seek', ( event ) => {
   automaton.reset();
 } );
 
+automaton.resume( 'fxDefinitionResume' );
+
 // == canvas =======================================================================================
 const width = canvas.width = 320;
 const height = canvas.height = 320;

--- a/packages/automaton-with-gui/playground-examples/fxs.js
+++ b/packages/automaton-with-gui/playground-examples/fxs.js
@@ -58,6 +58,8 @@ automaton.on( 'seek', ( event ) => {
   automaton.reset();
 } );
 
+automaton.resume( 'fxsResume' );
+
 // == canvas =======================================================================================
 const width = canvas.width = 320;
 const height = canvas.height = 320;

--- a/packages/automaton-with-gui/playground-examples/getting-started.js
+++ b/packages/automaton-with-gui/playground-examples/getting-started.js
@@ -72,6 +72,11 @@ automaton.on( 'seek', ( event ) => {
   automaton.reset(); // we should call this when we modify the time backwards
 } );
 
+// This is optional but, by using the method `resume`,
+// you can resume from the last time it closed, using Local Storage.
+
+automaton.resume( 'gettingStartedResume' ); // specifies the local storage key
+
 // == canvas =======================================================================================
 
 // We are going to create a program that simply shows a rect using canvas API.

--- a/packages/automaton-with-gui/playground-examples/gui.js
+++ b/packages/automaton-with-gui/playground-examples/gui.js
@@ -66,6 +66,8 @@ automaton.on( 'seek', ( event ) => {
   automaton.reset();
 } );
 
+automaton.resume( 'guiResume' );
+
 const width = canvas.width = 320;
 const height = canvas.height = 320;
 

--- a/packages/automaton-with-gui/src/AutomatonWithGUI.tsx
+++ b/packages/automaton-with-gui/src/AutomatonWithGUI.tsx
@@ -259,7 +259,7 @@ export class AutomatonWithGUI extends Automaton
     if ( typeof window !== 'undefined' ) {
       window.addEventListener( 'beforeunload', ( event ) => {
         if ( this.shouldSave ) {
-          const confirmationMessage = 'Automaton: Did you saved your progress?';
+          const confirmationMessage = 'Automaton: Did you save your progress?';
           event.returnValue = confirmationMessage;
           return confirmationMessage;
         }

--- a/packages/automaton-with-gui/src/AutomatonWithGUI.tsx
+++ b/packages/automaton-with-gui/src/AutomatonWithGUI.tsx
@@ -841,10 +841,15 @@ export class AutomatonWithGUI extends Automaton
    * Make sure you call this after you subscribe to `play` / `pause` / `seek`,
    * otherwise it won't work properly.
    *
-   * @param key A key which will be used for the local storage. Set a unique value.
+   * @param key A key that will be used for the local storage.
+   * Set a unique value between projects, especially if you are constantly using `localhost:3000` for every project.
+   * Uses `"automatonResume"` by default.
    */
-  public resume( key: string ): void {
-    const storage = this.__resumeStorage = new ThrottledJSONStorage<ResumeStorage>( key, 500 );
+  public resume( key?: string ): void {
+    const storage = this.__resumeStorage = new ThrottledJSONStorage<ResumeStorage>(
+      key ?? 'automatonResume',
+      500,
+    );
 
     const resumeIsPlaying = storage.get( 'isPlaying' );
     if ( resumeIsPlaying != null ) {

--- a/packages/automaton-with-gui/src/AutomatonWithGUI.tsx
+++ b/packages/automaton-with-gui/src/AutomatonWithGUI.tsx
@@ -8,8 +8,10 @@ import { EventEmittable } from './mixins/EventEmittable';
 import { GUIRemocon } from './GUIRemocon';
 import { GUISettings, defaultGUISettings } from './types/GUISettings';
 import { MinimizeOptions } from './types/MinimizeOptions';
+import { ResumeStorage } from './ResumeStorage';
 import { Serializable } from './types/Serializable';
 import { SerializedAutomatonWithGUI, defaultDataWithGUI } from './types/SerializedAutomatonWithGUI';
+import { ThrottledJSONStorage } from './ThrottledJSONStorage';
 import { WithID } from './types/WithID';
 import { applyMixins } from './utils/applyMixins';
 import { compat } from './compat/compat';
@@ -33,7 +35,9 @@ export interface AutomatonWithGUIOptions extends AutomatonOptions {
   gui?: HTMLElement;
 
   /**
-   * Initial state of play / pause. `false` by default.
+   * Initial state of play / pause.
+   *
+   * @default false
    */
   isPlaying?: boolean;
 
@@ -125,6 +129,13 @@ export class AutomatonWithGUI extends Automaton
    * It's currently playing or not.
    */
   protected __isPlaying: boolean;
+
+  /**
+   * A storage stores {@link resume} related values.
+   *
+   * If the resume feature is not used, it won't be set.
+   */
+  private __resumeStorage?: ThrottledJSONStorage<ResumeStorage>;
 
   /**
    * Whether it disables not used warning for channels or not.
@@ -239,11 +250,11 @@ export class AutomatonWithGUI extends Automaton
     super( compat( data ), options );
     this.mapNameToChannel = new BiMap<string, ChannelWithGUI>( this.mapNameToChannel );
 
-    this.__isPlaying = options.isPlaying || false;
+    this.__isPlaying = options.isPlaying ?? false;
 
     this.overrideSave = options.overrideSave;
     this.saveContextMenuCommands = options.saveContextMenuCommands;
-    this.__isDisabledChannelNotUsedWarning = options.disableChannelNotUsedWarning || false;
+    this.__isDisabledChannelNotUsedWarning = options.disableChannelNotUsedWarning ?? false;
 
     // if `options.disableChannelNotUsedWarning` is true, mark every channels as used
     if ( this.__isDisabledChannelNotUsedWarning ) {
@@ -283,6 +294,7 @@ export class AutomatonWithGUI extends Automaton
    * Can be performed via GUI.
    */
   public play(): void {
+    this.__resumeStorage?.set( 'isPlaying', true );
     this.__emit( 'play' );
     this.__isPlaying = true;
   }
@@ -293,6 +305,7 @@ export class AutomatonWithGUI extends Automaton
    * Can be performed via GUI.
    */
   public pause(): void {
+    this.__resumeStorage?.set( 'isPlaying', false );
     this.__emit( 'pause' );
     this.__isPlaying = false;
   }
@@ -325,6 +338,7 @@ export class AutomatonWithGUI extends Automaton
   public update( time: number ): void {
     super.update( time );
 
+    this.__resumeStorage?.set( 'time', this.time );
     this.__emit( 'update', { time: this.time } );
 
     if ( this.__loopRegion ) {
@@ -814,7 +828,40 @@ export class AutomatonWithGUI extends Automaton
    */
   public setLoopRegion( loopRegion: { begin: number; end: number } | null ): void {
     this.__loopRegion = loopRegion;
+    this.__resumeStorage?.set( 'loopRegion', loopRegion );
     this.__emit( 'setLoopRegion', { loopRegion } );
+  }
+
+  /**
+   * Try to resume a playback position from the last time it closed, using [Local Storage](https://developer.mozilla.org/ja/docs/Web/API/Window/localStorage).
+   * Once the function is called, it starts to record the current playback position on the local storage.
+   *
+   * It also saves the "isPlaying" and the loop region. How generous!
+   *
+   * Make sure you call this after you subscribe to `play` / `pause` / `seek`,
+   * otherwise it won't work properly.
+   *
+   * @param key A key which will be used for the local storage. Set a unique value.
+   */
+  public resume( key: string ): void {
+    const storage = this.__resumeStorage = new ThrottledJSONStorage<ResumeStorage>( key, 500 );
+
+    const resumeIsPlaying = storage.get( 'isPlaying' );
+    if ( resumeIsPlaying != null ) {
+      if ( this.__isPlaying !== resumeIsPlaying ) {
+        this.togglePlay();
+      }
+    }
+
+    const resumeTime = storage.get( 'time' );
+    if ( resumeTime != null ) {
+      this.seek( resumeTime );
+    }
+
+    const resumeLoopRegion = storage.get( 'loopRegion' );
+    if ( resumeLoopRegion != null ) {
+      this.setLoopRegion( resumeLoopRegion );
+    }
   }
 
   /**

--- a/packages/automaton-with-gui/src/AutomatonWithGUI.tsx
+++ b/packages/automaton-with-gui/src/AutomatonWithGUI.tsx
@@ -838,7 +838,7 @@ export class AutomatonWithGUI extends Automaton
    *
    * It also saves the "isPlaying" and the loop region. How generous!
    *
-   * Make sure you call this after you subscribe to `play` / `pause` / `seek`,
+   * Make sure you subscribe to `play`, `pause`, and `seek` events before you call `resume()`.
    * otherwise it won't work properly.
    *
    * @param key A key that will be used for the local storage.

--- a/packages/automaton-with-gui/src/ResumeStorage.ts
+++ b/packages/automaton-with-gui/src/ResumeStorage.ts
@@ -1,0 +1,5 @@
+export interface ResumeStorage {
+  isPlaying: boolean;
+  time: number;
+  loopRegion: { begin: number; end: number } | null;
+}

--- a/packages/automaton-with-gui/src/ThrottledJSONStorage.ts
+++ b/packages/automaton-with-gui/src/ThrottledJSONStorage.ts
@@ -1,0 +1,40 @@
+import { Throttle } from './utils/Throttle';
+
+export class ThrottledJSONStorage<T> {
+  public readonly key: string;
+
+  /**
+   * Do not write to this directly.
+   * Use {@link set} instead.
+   */
+  public readonly values: T;
+
+  private __throttle: Throttle;
+
+  /**
+   * @param key The local storage key
+   * @param throttleRate Throttle rate, in ms
+   */
+  public constructor( key: string, throttleRate?: number ) {
+    this.key = key;
+
+    const valuesStr = localStorage.getItem( key );
+    this.values = valuesStr != null ? JSON.parse( valuesStr ) : {};
+
+    this.__throttle = new Throttle( throttleRate );
+  }
+
+  public get<TKey extends keyof T>( key: TKey ): T[ TKey ] | undefined {
+    return this.values[ key ];
+  }
+
+  public set<TKey extends keyof T>( key: TKey, value: T[ TKey ] ): void {
+    this.values[ key ] = value;
+    this.__throttle.do( () => this.__write() );
+  }
+
+  private __write(): void {
+    const value = JSON.stringify( this.values );
+    localStorage.setItem( this.key, value );
+  }
+}

--- a/packages/automaton-with-gui/src/utils/Throttle.ts
+++ b/packages/automaton-with-gui/src/utils/Throttle.ts
@@ -1,3 +1,13 @@
+/**
+ * @example
+ * ```ts
+ * const throttle = new Throttle();
+ *
+ * throttle.do( () => doExpensivePut() );
+ * throttle.do( () => doExpensivePut() );
+ * throttle.do( () => doExpensivePut() );
+ * ```
+ */
 export class Throttle<T = void> {
   /**
    * Rate, in ms.
@@ -9,6 +19,9 @@ export class Throttle<T = void> {
 
   private __lastTime = 0;
 
+  /**
+   * @param rate Rate, in ms.
+   */
   public constructor( rate?: number ) {
     this.rate = rate ?? 100;
   }


### PR DESCRIPTION
call `automaton.resume()` to resume a playback position from the last time you closed / reloaded / whenever.

It saves:
- playback position
- "isPlaying"
- loop region

It has to be called after subscribing to `play`, `pause`, and `seek` events otherwise it won't do anything.

I believe it's a massive iteration speed boost.
